### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/115/933/948/5/1159339485.geojson
+++ b/data/115/933/948/5/1159339485.geojson
@@ -447,6 +447,9 @@
         "wof:hierarchy"
     ],
     "wof:country":"XX",
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"0c74562d7e70a9c2365ae672428bb980",
     "wof:hierarchy":[
         {
@@ -463,7 +466,7 @@
         }
     ],
     "wof:id":1159339485,
-    "wof:lastmodified":1566654856,
+    "wof:lastmodified":1582332402,
     "wof:name":"Gaza Strip",
     "wof:parent_id":-2,
     "wof:placetype":"disputed",

--- a/data/115/933/948/7/1159339487.geojson
+++ b/data/115/933/948/7/1159339487.geojson
@@ -441,6 +441,9 @@
         "wof:hierarchy"
     ],
     "wof:country":"XX",
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"d1b4e71944f78427e2bd70e75187b3cc",
     "wof:hierarchy":[
         {
@@ -457,7 +460,7 @@
         }
     ],
     "wof:id":1159339487,
-    "wof:lastmodified":1566654855,
+    "wof:lastmodified":1582332401,
     "wof:name":"West Bank",
     "wof:parent_id":-2,
     "wof:placetype":"disputed",

--- a/data/115/933/949/5/1159339495.geojson
+++ b/data/115/933/949/5/1159339495.geojson
@@ -335,6 +335,9 @@
         "wof:hierarchy"
     ],
     "wof:country":"XX",
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"75ad44457ddd098bbbbe86a8b303a1b7",
     "wof:hierarchy":[
         {
@@ -349,7 +352,7 @@
         }
     ],
     "wof:id":1159339495,
-    "wof:lastmodified":1566654858,
+    "wof:lastmodified":1582332402,
     "wof:name":"Gilgit-Baltistan",
     "wof:parent_id":-2,
     "wof:placetype":"disputed",

--- a/data/115/933/949/7/1159339497.geojson
+++ b/data/115/933/949/7/1159339497.geojson
@@ -353,6 +353,9 @@
         "wof:hierarchy"
     ],
     "wof:country":"XX",
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"4fad1af1f416a90525cc4e42b2919cc1",
     "wof:hierarchy":[
         {
@@ -367,7 +370,7 @@
         }
     ],
     "wof:id":1159339497,
-    "wof:lastmodified":1566654857,
+    "wof:lastmodified":1582332402,
     "wof:name":"Azad Kashmir",
     "wof:parent_id":-2,
     "wof:placetype":"disputed",

--- a/data/115/933/950/3/1159339503.geojson
+++ b/data/115/933/950/3/1159339503.geojson
@@ -272,6 +272,9 @@
         "wof:hierarchy"
     ],
     "wof:country":"XX",
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"37c6cf1a517c8d63c34b975f7e42e084",
     "wof:hierarchy":[
         {
@@ -281,7 +284,7 @@
         }
     ],
     "wof:id":1159339503,
-    "wof:lastmodified":1566654859,
+    "wof:lastmodified":1582332402,
     "wof:name":"Korean Demilitarized Zone",
     "wof:parent_id":-2,
     "wof:placetype":"disputed",

--- a/data/115/933/950/5/1159339505.geojson
+++ b/data/115/933/950/5/1159339505.geojson
@@ -271,6 +271,9 @@
         "wof:hierarchy"
     ],
     "wof:country":"XX",
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"8cc81d9cbb77f97cc440a5e02f5ceca5",
     "wof:hierarchy":[
         {
@@ -280,7 +283,7 @@
         }
     ],
     "wof:id":1159339505,
-    "wof:lastmodified":1566654860,
+    "wof:lastmodified":1582332403,
     "wof:name":"Korean Demilitarized Zone",
     "wof:parent_id":-2,
     "wof:placetype":"disputed",

--- a/data/115/933/953/3/1159339533.geojson
+++ b/data/115/933/953/3/1159339533.geojson
@@ -625,6 +625,9 @@
         "wof:hierarchy"
     ],
     "wof:country":"XX",
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"47e6516d35a691f74b0eddc79d1ded36",
     "wof:hierarchy":[
         {
@@ -640,7 +643,7 @@
         }
     ],
     "wof:id":1159339533,
-    "wof:lastmodified":1566654852,
+    "wof:lastmodified":1582332401,
     "wof:name":"Gibraltar",
     "wof:parent_id":-2,
     "wof:placetype":"disputed",

--- a/data/856/321/77/85632177.geojson
+++ b/data/856/321/77/85632177.geojson
@@ -396,6 +396,10 @@
         "wof:hierarchy"
     ],
     "wof:country":"XX",
+    "wof:geom_alt":[
+        "naturalearth",
+        "quattroshapes"
+    ],
     "wof:geomhash":"64ced82165fe95869cb37742bfa1e0a1",
     "wof:hierarchy":[
         {
@@ -418,7 +422,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566653140,
+    "wof:lastmodified":1582332379,
     "wof:name":"Spratly Islands",
     "wof:parent_id":-2,
     "wof:placetype":"disputed",

--- a/data/856/321/95/85632195.geojson
+++ b/data/856/321/95/85632195.geojson
@@ -254,6 +254,9 @@
         "wof:hierarchy"
     ],
     "wof:country":"XX",
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"16d16d807e72795a1444db96eb585bb9",
     "wof:hierarchy":[
         {
@@ -267,7 +270,7 @@
     "wof:lang":[
         "fre"
     ],
-    "wof:lastmodified":1566653139,
+    "wof:lastmodified":1582332379,
     "wof:name":"Lawa Headwaters",
     "wof:parent_id":-2,
     "wof:placetype":"disputed",

--- a/data/856/322/21/85632221.geojson
+++ b/data/856/322/21/85632221.geojson
@@ -492,6 +492,10 @@
         "wof:hierarchy"
     ],
     "wof:country":"XX",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "naturalearth"
+    ],
     "wof:geomhash":"5a6e219b616570fe26e6e0d19c0053de",
     "wof:hierarchy":[
         {
@@ -506,7 +510,7 @@
         }
     ],
     "wof:id":85632221,
-    "wof:lastmodified":1566653134,
+    "wof:lastmodified":1582332378,
     "wof:name":"Golan Heights",
     "wof:parent_id":-2,
     "wof:placetype":"disputed",

--- a/data/856/322/51/85632251.geojson
+++ b/data/856/322/51/85632251.geojson
@@ -697,6 +697,9 @@
         "wof:hierarchy"
     ],
     "wof:country":"XX",
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"6501b0ccb5c098531b067144c8319676",
     "wof:hierarchy":[
         {
@@ -706,7 +709,7 @@
         }
     ],
     "wof:id":85632251,
-    "wof:lastmodified":1566653133,
+    "wof:lastmodified":1582332378,
     "wof:name":"Mayotte",
     "wof:parent_id":-2,
     "wof:placetype":"disputed",

--- a/data/856/322/65/85632265.geojson
+++ b/data/856/322/65/85632265.geojson
@@ -265,6 +265,9 @@
         "wof:hierarchy"
     ],
     "wof:country":"XX",
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"3861353df6ca881a1fd861619c24a796",
     "wof:hierarchy":[
         {
@@ -279,7 +282,7 @@
         }
     ],
     "wof:id":85632265,
-    "wof:lastmodified":1566653134,
+    "wof:lastmodified":1582332378,
     "wof:name":"Abyei Special Administrative Area",
     "wof:parent_id":-2,
     "wof:placetype":"disputed",

--- a/data/856/322/77/85632277.geojson
+++ b/data/856/322/77/85632277.geojson
@@ -330,6 +330,9 @@
         "wof:hierarchy"
     ],
     "wof:country":"XX",
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"bedf1fa95dc65251c279dd7f4e175f2a",
     "wof:hierarchy":[
         {
@@ -344,7 +347,7 @@
         }
     ],
     "wof:id":85632277,
-    "wof:lastmodified":1566653134,
+    "wof:lastmodified":1582332378,
     "wof:name":"Siachen Glacier",
     "wof:parent_id":-2,
     "wof:placetype":"disputed",

--- a/data/856/322/89/85632289.geojson
+++ b/data/856/322/89/85632289.geojson
@@ -301,6 +301,10 @@
         "wof:hierarchy"
     ],
     "wof:country":"XX",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "naturalearth"
+    ],
     "wof:geomhash":"0eca541c5d6f2e44e2394be4d0d8b884",
     "wof:hierarchy":[
         {
@@ -315,7 +319,7 @@
         }
     ],
     "wof:id":85632289,
-    "wof:lastmodified":1566653133,
+    "wof:lastmodified":1582332378,
     "wof:name":"Shebaa Farms",
     "wof:parent_id":-2,
     "wof:placetype":"disputed",

--- a/data/856/323/49/85632349.geojson
+++ b/data/856/323/49/85632349.geojson
@@ -245,6 +245,9 @@
         "wof:hierarchy"
     ],
     "wof:country":"XX",
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"bdae6ac65278f16025bb26e7c6cff9c0",
     "wof:hierarchy":[
         {
@@ -259,7 +262,7 @@
         }
     ],
     "wof:id":85632349,
-    "wof:lastmodified":1566653133,
+    "wof:lastmodified":1582332377,
     "wof:name":"Tiran and Sanafir Islands",
     "wof:parent_id":-2,
     "wof:placetype":"disputed",

--- a/data/856/323/53/85632353.geojson
+++ b/data/856/323/53/85632353.geojson
@@ -317,6 +317,9 @@
         "wof:hierarchy"
     ],
     "wof:country":"XX",
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"de41d709531e2242843501056d7fd7b7",
     "wof:hierarchy":[
         {
@@ -326,7 +329,7 @@
         }
     ],
     "wof:id":85632353,
-    "wof:lastmodified":1566653133,
+    "wof:lastmodified":1582332377,
     "wof:name":"Dokdo",
     "wof:parent_id":-2,
     "wof:placetype":"disputed",

--- a/data/856/323/67/85632367.geojson
+++ b/data/856/323/67/85632367.geojson
@@ -187,6 +187,9 @@
         "wof:hierarchy"
     ],
     "wof:country":"XX",
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"201129462035d5549ebc2c1f9c384ab4",
     "wof:hierarchy":[
         {
@@ -201,7 +204,7 @@
         }
     ],
     "wof:id":85632367,
-    "wof:lastmodified":1566653132,
+    "wof:lastmodified":1582332377,
     "wof:name":"Mbane Island",
     "wof:parent_id":-2,
     "wof:placetype":"disputed",

--- a/data/856/323/75/85632375.geojson
+++ b/data/856/323/75/85632375.geojson
@@ -574,6 +574,9 @@
         "wof:hierarchy"
     ],
     "wof:country":"XX",
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"1cda84c2113747450cd9797e953c3bb7",
     "wof:hierarchy":[
         {
@@ -588,7 +591,7 @@
         }
     ],
     "wof:id":85632375,
-    "wof:lastmodified":1566653132,
+    "wof:lastmodified":1582332377,
     "wof:name":"Northern Cyprus",
     "wof:parent_id":-2,
     "wof:placetype":"disputed",

--- a/data/856/323/77/85632377.geojson
+++ b/data/856/323/77/85632377.geojson
@@ -211,6 +211,9 @@
         "wof:hierarchy"
     ],
     "wof:country":"XX",
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"0bf995ac61fafca0992e8fd19bb30cfb",
     "wof:hierarchy":[
         {
@@ -225,7 +228,7 @@
         }
     ],
     "wof:id":85632377,
-    "wof:lastmodified":1566653133,
+    "wof:lastmodified":1582332377,
     "wof:name":"Demchok",
     "wof:parent_id":-2,
     "wof:placetype":"disputed",

--- a/data/856/324/15/85632415.geojson
+++ b/data/856/324/15/85632415.geojson
@@ -330,6 +330,9 @@
         "wof:hierarchy"
     ],
     "wof:country":"XX",
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"5e42068808d1c7d70dc5f290afdb042b",
     "wof:hierarchy":[
         {
@@ -344,7 +347,7 @@
         }
     ],
     "wof:id":85632415,
-    "wof:lastmodified":1566653131,
+    "wof:lastmodified":1582332377,
     "wof:name":"Aksai Chin",
     "wof:parent_id":-2,
     "wof:placetype":"disputed",

--- a/data/856/324/27/85632427.geojson
+++ b/data/856/324/27/85632427.geojson
@@ -526,6 +526,10 @@
         "wof:hierarchy"
     ],
     "wof:country":"XX",
+    "wof:geom_alt":[
+        "naturalearth",
+        "quattroshapes"
+    ],
     "wof:geomhash":"751ffd784e526b5136b8fa331fd3b5b4",
     "wof:hierarchy":[
         {
@@ -540,7 +544,7 @@
         }
     ],
     "wof:id":85632427,
-    "wof:lastmodified":1566653130,
+    "wof:lastmodified":1582332376,
     "wof:name":"Jammu and Kashmir",
     "wof:parent_id":-2,
     "wof:placetype":"disputed",

--- a/data/856/324/45/85632445.geojson
+++ b/data/856/324/45/85632445.geojson
@@ -134,6 +134,9 @@
         "qs_pg:id":1314360
     },
     "wof:country":"XX",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1284680095619a81eea78aa57e072786",
     "wof:hierarchy":[
         {
@@ -143,7 +146,7 @@
         }
     ],
     "wof:id":85632445,
-    "wof:lastmodified":1566653131,
+    "wof:lastmodified":1582332377,
     "wof:name":"No Man's Land (Fort Latrun)",
     "wof:parent_id":85632315,
     "wof:placetype":"disputed",

--- a/data/856/324/47/85632447.geojson
+++ b/data/856/324/47/85632447.geojson
@@ -199,6 +199,9 @@
         "wof:hierarchy"
     ],
     "wof:country":"XX",
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"3abc42d1ae22a7cbfaaa1139b92cd197",
     "wof:hierarchy":[
         {
@@ -213,7 +216,7 @@
         }
     ],
     "wof:id":85632447,
-    "wof:lastmodified":1566653132,
+    "wof:lastmodified":1582332377,
     "wof:name":"Shaksam Valley",
     "wof:parent_id":-2,
     "wof:placetype":"disputed",

--- a/data/856/324/57/85632457.geojson
+++ b/data/856/324/57/85632457.geojson
@@ -355,6 +355,9 @@
         "wof:hierarchy"
     ],
     "wof:country":"XX",
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"5d76ceaea473a069038b8c5d6c859298",
     "wof:hierarchy":[
         {
@@ -374,7 +377,7 @@
         }
     ],
     "wof:id":85632457,
-    "wof:lastmodified":1566653129,
+    "wof:lastmodified":1582332376,
     "wof:name":"Paracel Islands",
     "wof:parent_id":-2,
     "wof:placetype":"disputed",

--- a/data/856/324/63/85632463.geojson
+++ b/data/856/324/63/85632463.geojson
@@ -182,6 +182,9 @@
         "wof:hierarchy"
     ],
     "wof:country":"XX",
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"eea273692d6d7d2d0983a1de4ecdf318",
     "wof:hierarchy":[
         {
@@ -196,7 +199,7 @@
         }
     ],
     "wof:id":85632463,
-    "wof:lastmodified":1566653131,
+    "wof:lastmodified":1582332377,
     "wof:name":"Bara Hotii Valleys",
     "wof:parent_id":-2,
     "wof:placetype":"disputed",

--- a/data/856/324/79/85632479.geojson
+++ b/data/856/324/79/85632479.geojson
@@ -304,6 +304,9 @@
         "wof:hierarchy"
     ],
     "wof:country":"XX",
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"6367a6ef8adff5ba30e3099e835572a2",
     "wof:hierarchy":[
         {
@@ -318,7 +321,7 @@
         }
     ],
     "wof:id":85632479,
-    "wof:lastmodified":1566653131,
+    "wof:lastmodified":1582332377,
     "wof:name":"Scarborough Reef",
     "wof:parent_id":-2,
     "wof:placetype":"disputed",

--- a/data/856/325/15/85632515.geojson
+++ b/data/856/325/15/85632515.geojson
@@ -202,6 +202,9 @@
         "wof:hierarchy"
     ],
     "wof:country":"XX",
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"1ecd1b95cc0030745f65f7e41aa1912d",
     "wof:hierarchy":[
         {
@@ -221,7 +224,7 @@
         }
     ],
     "wof:id":85632515,
-    "wof:lastmodified":1566653136,
+    "wof:lastmodified":1582332378,
     "wof:name":"Sapodilla Cayes",
     "wof:parent_id":-2,
     "wof:placetype":"disputed",

--- a/data/856/325/27/85632527.geojson
+++ b/data/856/325/27/85632527.geojson
@@ -951,6 +951,9 @@
         "wof:hierarchy"
     ],
     "wof:country":"XX",
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"34a45722b2bedf94733ea2c42bfaa27a",
     "wof:hierarchy":[
         {
@@ -973,7 +976,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566653134,
+    "wof:lastmodified":1582332378,
     "wof:name":"United Nations Buffer Zone in Cyprus",
     "wof:parent_id":-2,
     "wof:placetype":"disputed",

--- a/data/856/325/63/85632563.geojson
+++ b/data/856/325/63/85632563.geojson
@@ -431,6 +431,9 @@
         "wof:belongsto"
     ],
     "wof:country":"XX",
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"f1343bbf0eb3460f13c62fae769a52ea",
     "wof:hierarchy":[
         {
@@ -460,7 +463,7 @@
         }
     ],
     "wof:id":85632563,
-    "wof:lastmodified":1566653135,
+    "wof:lastmodified":1582332378,
     "wof:name":"Bajo Nuevo Bank",
     "wof:parent_id":-2,
     "wof:placetype":"disputed",

--- a/data/856/325/77/85632577.geojson
+++ b/data/856/325/77/85632577.geojson
@@ -181,6 +181,9 @@
         "wof:hierarchy"
     ],
     "wof:country":"XX",
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"ecfa289caff91a0e797de02e524cd2a5",
     "wof:hierarchy":[
         {
@@ -195,7 +198,7 @@
         }
     ],
     "wof:id":85632577,
-    "wof:lastmodified":1566653135,
+    "wof:lastmodified":1582332378,
     "wof:name":"Tirpani Valleys",
     "wof:parent_id":-2,
     "wof:placetype":"disputed",

--- a/data/856/325/89/85632589.geojson
+++ b/data/856/325/89/85632589.geojson
@@ -134,6 +134,9 @@
         "qs_pg:id":1314360
     },
     "wof:country":"XX",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ea8b18179bb99a5feb07d26dca8dc011",
     "wof:hierarchy":[
         {
@@ -152,7 +155,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566653135,
+    "wof:lastmodified":1582332378,
     "wof:name":"No Man's Land (Jerusalem)",
     "wof:parent_id":-1,
     "wof:placetype":"disputed",

--- a/data/856/325/95/85632595.geojson
+++ b/data/856/325/95/85632595.geojson
@@ -181,6 +181,9 @@
         "wof:hierarchy"
     ],
     "wof:country":"XX",
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"f59bb84e1ebf2e382dc00f77fc4dc99c",
     "wof:hierarchy":[
         {
@@ -195,7 +198,7 @@
         }
     ],
     "wof:id":85632595,
-    "wof:lastmodified":1566653134,
+    "wof:lastmodified":1582332378,
     "wof:name":"Samdu Valleys",
     "wof:parent_id":-2,
     "wof:placetype":"disputed",

--- a/data/856/326/01/85632601.geojson
+++ b/data/856/326/01/85632601.geojson
@@ -286,6 +286,9 @@
         "wof:hierarchy"
     ],
     "wof:country":"XX",
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"9d15ba05b73a14533ec5d3110844f683",
     "wof:hierarchy":[
         {
@@ -300,7 +303,7 @@
         }
     ],
     "wof:id":85632601,
-    "wof:lastmodified":1566653138,
+    "wof:lastmodified":1582332379,
     "wof:name":"Abu Musa Island",
     "wof:parent_id":-2,
     "wof:placetype":"disputed",

--- a/data/856/326/19/85632619.geojson
+++ b/data/856/326/19/85632619.geojson
@@ -436,6 +436,9 @@
         "wof:hierarchy"
     ],
     "wof:country":"XX",
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"456ec9eef5e6b3c1a7468667b6eedf35",
     "wof:hierarchy":[
         {
@@ -445,7 +448,7 @@
         }
     ],
     "wof:id":85632619,
-    "wof:lastmodified":1566653138,
+    "wof:lastmodified":1582332379,
     "wof:name":"Kuril Islands",
     "wof:parent_id":-2,
     "wof:placetype":"disputed",

--- a/data/856/326/21/85632621.geojson
+++ b/data/856/326/21/85632621.geojson
@@ -357,6 +357,9 @@
         "wof:hierarchy"
     ],
     "wof:country":"XX",
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"762a42ab0f1ecac77025a89ba755faf5",
     "wof:hierarchy":[
         {
@@ -371,7 +374,7 @@
         }
     ],
     "wof:id":85632621,
-    "wof:lastmodified":1566653138,
+    "wof:lastmodified":1582332379,
     "wof:name":"Pinnacle Island",
     "wof:parent_id":-2,
     "wof:placetype":"disputed",

--- a/data/856/326/55/85632655.geojson
+++ b/data/856/326/55/85632655.geojson
@@ -201,6 +201,9 @@
         "wof:hierarchy"
     ],
     "wof:country":"XX",
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"7e9fd3fd3c5120b0a22c863b9e96e192",
     "wof:hierarchy":[
         {
@@ -215,7 +218,7 @@
         }
     ],
     "wof:id":85632655,
-    "wof:lastmodified":1566653139,
+    "wof:lastmodified":1582332379,
     "wof:name":"Om Parvat",
     "wof:parent_id":-2,
     "wof:placetype":"disputed",

--- a/data/856/327/01/85632701.geojson
+++ b/data/856/327/01/85632701.geojson
@@ -492,6 +492,9 @@
         "wof:hierarchy"
     ],
     "wof:country":"XX",
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"ab9478a0c3c294b1ad8f5eaeafa03948",
     "wof:hierarchy":[
         {
@@ -509,7 +512,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566653137,
+    "wof:lastmodified":1582332378,
     "wof:name":"Arunachal Pradesh (Southern Tibet)",
     "wof:parent_id":-2,
     "wof:placetype":"disputed",

--- a/data/856/327/11/85632711.geojson
+++ b/data/856/327/11/85632711.geojson
@@ -204,6 +204,10 @@
         "wof:hierarchy"
     ],
     "wof:country":"XX",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "naturalearth"
+    ],
     "wof:geomhash":"81ad9569e25aeaa829cbbc701e765520",
     "wof:hierarchy":[
         {
@@ -221,7 +225,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566653136,
+    "wof:lastmodified":1582332378,
     "wof:name":"United Nations Disengagement Observer Force Zone",
     "wof:parent_id":-2,
     "wof:placetype":"disputed",

--- a/data/856/811/55/85681155.geojson
+++ b/data/856/811/55/85681155.geojson
@@ -308,6 +308,9 @@
         "wof:belongsto"
     ],
     "wof:country":"XX",
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"065abcb2fc412456d94e30525d4098dd",
     "wof:hierarchy":[
         {
@@ -342,7 +345,7 @@
         }
     ],
     "wof:id":85681155,
-    "wof:lastmodified":1566653129,
+    "wof:lastmodified":1582332376,
     "wof:name":"Bajo Nuevo Bank",
     "wof:parent_id":-2,
     "wof:placetype":"region",

--- a/data/856/813/63/85681363.geojson
+++ b/data/856/813/63/85681363.geojson
@@ -301,6 +301,9 @@
         "wof:hierarchy"
     ],
     "wof:country":"XX",
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"53ab8979fd992592faa18248f6c66b69",
     "wof:hierarchy":[
         {
@@ -325,7 +328,7 @@
         }
     ],
     "wof:id":85681363,
-    "wof:lastmodified":1566653136,
+    "wof:lastmodified":1582332378,
     "wof:name":"Serranilla Bank",
     "wof:parent_id":-2,
     "wof:placetype":"disputed",

--- a/data/857/835/29/85783529.geojson
+++ b/data/857/835/29/85783529.geojson
@@ -68,6 +68,9 @@
         "qs:id":128217
     },
     "wof:country":"XX",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0c02d0ec47b6d1f6f04b51fe312fb728",
     "wof:hierarchy":[
         {
@@ -82,7 +85,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1534379828,
+    "wof:lastmodified":1582332375,
     "wof:name":"Valia Veli",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/038/87/85903887.geojson
+++ b/data/859/038/87/85903887.geojson
@@ -104,6 +104,9 @@
         "wd:id":"Q658886"
     },
     "wof:country":"XX",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"213eabc6236d7d312654a78d584e464e",
     "wof:hierarchy":[
         {
@@ -118,7 +121,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566653127,
+    "wof:lastmodified":1582332375,
     "wof:name":"Kathivakkam",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/260/01/85926001.geojson
+++ b/data/859/260/01/85926001.geojson
@@ -72,6 +72,10 @@
         "qs_pg:id":427072
     },
     "wof:country":"XX",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"eac57a4de3405edc3f831bdcd0f6dc1b",
     "wof:hierarchy":[
         {
@@ -86,7 +90,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566653128,
+    "wof:lastmodified":1582332375,
     "wof:name":"\ub0b4\uac00\uba74",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/260/17/85926017.geojson
+++ b/data/859/260/17/85926017.geojson
@@ -72,6 +72,10 @@
         "qs_pg:id":1091446
     },
     "wof:country":"XX",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"2470e8e46427ad7375100d3ecb329e16",
     "wof:hierarchy":[
         {
@@ -86,7 +90,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566653127,
+    "wof:lastmodified":1582332375,
     "wof:name":"\ubd81\ub3c4\uba74",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/260/21/85926021.geojson
+++ b/data/859/260/21/85926021.geojson
@@ -78,6 +78,10 @@
         "qs_pg:id":1294595
     },
     "wof:country":"XX",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"cd9b462a110009f18945469024c380b2",
     "wof:hierarchy":[
         {
@@ -93,7 +97,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566653127,
+    "wof:lastmodified":1582332375,
     "wof:name":"\uc601\ud765\uba74",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/260/25/85926025.geojson
+++ b/data/859/260/25/85926025.geojson
@@ -72,6 +72,10 @@
         "qs_pg:id":1294596
     },
     "wof:country":"XX",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b022be87bc7c5429e647b265aebf59b3",
     "wof:hierarchy":[
         {
@@ -86,7 +90,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566653128,
+    "wof:lastmodified":1582332375,
     "wof:name":"\uc790\uc6d4\uba74",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/264/71/85926471.geojson
+++ b/data/859/264/71/85926471.geojson
@@ -63,6 +63,10 @@
         "qs_pg:id":993072
     },
     "wof:country":"XX",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"dfa0a420ad8dd4e061919e4776d88a85",
     "wof:hierarchy":[
         {
@@ -77,7 +81,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566653128,
+    "wof:lastmodified":1582332375,
     "wof:name":"\uc601\uc120\ub3d9",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/277/95/85927795.geojson
+++ b/data/859/277/95/85927795.geojson
@@ -88,6 +88,9 @@
         "qs_pg:id":960980
     },
     "wof:country":"XX",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"66cb4e28a256ad2224f691c0795ffd0f",
     "wof:hierarchy":[
         {
@@ -113,7 +116,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566653128,
+    "wof:lastmodified":1582332375,
     "wof:name":"Takia Magam",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/278/49/85927849.geojson
+++ b/data/859/278/49/85927849.geojson
@@ -70,6 +70,9 @@
         "gp:id":29214771
     },
     "wof:country":"XX",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6e64040fb4436e1e7ed7822c6d8817aa",
     "wof:hierarchy":[
         {
@@ -95,7 +98,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566653128,
+    "wof:lastmodified":1582332375,
     "wof:name":"Mulbek",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/341/37/85934137.geojson
+++ b/data/859/341/37/85934137.geojson
@@ -90,6 +90,9 @@
         "qs_pg:id":476981
     },
     "wof:country":"XX",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"826bde9b4d9fcb38e9b523ea345dda12",
     "wof:hierarchy":[
         {
@@ -115,7 +118,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566653128,
+    "wof:lastmodified":1582332375,
     "wof:name":"Shalimar Bagh",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/342/27/85934227.geojson
+++ b/data/859/342/27/85934227.geojson
@@ -67,6 +67,9 @@
         "gp:id":55958110
     },
     "wof:country":"XX",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9af9f12bbc79d755e169c35562a35b70",
     "wof:hierarchy":[
         {
@@ -92,7 +95,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566653129,
+    "wof:lastmodified":1582332375,
     "wof:name":"Changspa",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/342/31/85934231.geojson
+++ b/data/859/342/31/85934231.geojson
@@ -94,6 +94,9 @@
         "qs_pg:id":1346706
     },
     "wof:country":"XX",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2e77305febb9f492bb2cd8ed06cab1fa",
     "wof:hierarchy":[
         {
@@ -119,7 +122,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566653129,
+    "wof:lastmodified":1582332375,
     "wof:name":"Suku",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/342/67/85934267.geojson
+++ b/data/859/342/67/85934267.geojson
@@ -71,6 +71,9 @@
         "qs:id":922174
     },
     "wof:country":"XX",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b3f05a035a8a21971393a63afb641c27",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1534379828,
+    "wof:lastmodified":1582332375,
     "wof:name":"Karzoo",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/890/451/987/890451987.geojson
+++ b/data/890/451/987/890451987.geojson
@@ -107,6 +107,9 @@
     },
     "wof:country":"XX",
     "wof:created":1469052800,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7ac8881630532a67203aa142fa1a07cb",
     "wof:hierarchy":[
         {
@@ -117,7 +120,7 @@
         }
     ],
     "wof:id":890451987,
-    "wof:lastmodified":1566653161,
+    "wof:lastmodified":1582332380,
     "wof:name":"Saida",
     "wof:parent_id":85673499,
     "wof:placetype":"county",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.