### PR TITLE
Update non-ascii names, store existing localized names

### DIFF
--- a/data/112/528/858/1/1125288581.geojson
+++ b/data/112/528/858/1/1125288581.geojson
@@ -20,6 +20,15 @@
     "mz:is_funky":1,
     "mz:min_zoom":12.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:eng_x_preferred":[
+        "Qihe"
+    ],
+    "name:eng_x_variant":[
+        "Qihe County"
+    ],
+    "name:zho_x_preferred":[
+        "\u9f50\u6cb3\u53bf"
+    ],
     "qs_pg:gn_country":"CN",
     "qs_pg:name":"\u9f50\u6cb3\u53bf",
     "qs_pg:name_adm0":"\u4e2d\u570b",
@@ -60,8 +69,8 @@
         }
     ],
     "wof:id":1125288581,
-    "wof:lastmodified":1566653464,
-    "wof:name":"\u9f50\u6cb3\u53bf",
+    "wof:lastmodified":1601427755,
+    "wof:name":"Qihe",
     "wof:parent_id":-1,
     "wof:placetype":"localadmin",
     "wof:repo":"whosonfirst-data-admin-xx",

--- a/data/112/534/096/7/1125340967.geojson
+++ b/data/112/534/096/7/1125340967.geojson
@@ -20,6 +20,15 @@
     "mz:is_funky":1,
     "mz:min_zoom":12.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:eng_x_preferred":[
+        "Huangyan"
+    ],
+    "name:eng_x_variant":[
+        "Huangyan District"
+    ],
+    "name:zho_x_preferred":[
+        "\u9ec4\u5ca9\u533a"
+    ],
     "qs_pg:gn_country":"CN",
     "qs_pg:name":"\u9ec4\u5ca9\u533a",
     "qs_pg:name_adm0":"\u4e2d\u570b",
@@ -60,8 +69,8 @@
         }
     ],
     "wof:id":1125340967,
-    "wof:lastmodified":1566653192,
-    "wof:name":"\u9ec4\u5ca9\u533a",
+    "wof:lastmodified":1601427754,
+    "wof:name":"Huangyan",
     "wof:parent_id":-1,
     "wof:placetype":"localadmin",
     "wof:repo":"whosonfirst-data-admin-xx",

--- a/data/112/535/293/1/1125352931.geojson
+++ b/data/112/535/293/1/1125352931.geojson
@@ -20,6 +20,15 @@
     "mz:is_funky":1,
     "mz:min_zoom":12.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:eng_x_preferred":[
+        "Wannian"
+    ],
+    "name:eng_x_variant":[
+        "Wannian County"
+    ],
+    "name:zho_x_preferred":[
+        "\u4e07\u5e74\u53bf"
+    ],
     "qs_pg:gn_country":"CN",
     "qs_pg:name":"\u4e07\u5e74\u53bf",
     "qs_pg:name_adm0":"\u4e2d\u570b",
@@ -60,8 +69,8 @@
         }
     ],
     "wof:id":1125352931,
-    "wof:lastmodified":1566653242,
-    "wof:name":"\u4e07\u5e74\u53bf",
+    "wof:lastmodified":1601427755,
+    "wof:name":"Wannian",
     "wof:parent_id":-1,
     "wof:placetype":"localadmin",
     "wof:repo":"whosonfirst-data-admin-xx",

--- a/data/112/535/965/3/1125359653.geojson
+++ b/data/112/535/965/3/1125359653.geojson
@@ -20,6 +20,15 @@
     "mz:is_funky":1,
     "mz:min_zoom":12.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:eng_x_preferred":[
+        "Moyu"
+    ],
+    "name:eng_x_variant":[
+        "Moyu County"
+    ],
+    "name:zho_x_preferred":[
+        "\u58a8\u7389\u53bf"
+    ],
     "qs_pg:gn_country":"CN",
     "qs_pg:name":"\u58a8\u7389\u53bf",
     "qs_pg:name_adm0":"\u4e2d\u570b",
@@ -60,8 +69,8 @@
         }
     ],
     "wof:id":1125359653,
-    "wof:lastmodified":1566653227,
-    "wof:name":"\u58a8\u7389\u53bf",
+    "wof:lastmodified":1601427754,
+    "wof:name":"Moyu",
     "wof:parent_id":-1,
     "wof:placetype":"localadmin",
     "wof:repo":"whosonfirst-data-admin-xx",

--- a/data/112/536/415/5/1125364155.geojson
+++ b/data/112/536/415/5/1125364155.geojson
@@ -20,6 +20,15 @@
     "mz:is_funky":1,
     "mz:min_zoom":12.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:eng_x_preferred":[
+        "Lichuan"
+    ],
+    "name:eng_x_variant":[
+        "Lichuan District"
+    ],
+    "name:zho_x_preferred":[
+        "\u9ece\u5ddd\u533a"
+    ],
     "qs_pg:gn_country":"CN",
     "qs_pg:name":"\u9ece\u5ddd\u533a",
     "qs_pg:name_adm0":"\u4e2d\u570b",
@@ -60,8 +69,8 @@
         }
     ],
     "wof:id":1125364155,
-    "wof:lastmodified":1566654020,
-    "wof:name":"\u9ece\u5ddd\u533a",
+    "wof:lastmodified":1601427754,
+    "wof:name":"Lichuan",
     "wof:parent_id":-1,
     "wof:placetype":"localadmin",
     "wof:repo":"whosonfirst-data-admin-xx",

--- a/data/112/537/644/1/1125376441.geojson
+++ b/data/112/537/644/1/1125376441.geojson
@@ -20,6 +20,12 @@
     "mz:is_funky":1,
     "mz:min_zoom":12.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:eng_x_preferred":[
+        "Yuji"
+    ],
+    "name:zho_x_preferred":[
+        "\u9ed2\u5ca9"
+    ],
     "qs_pg:gn_country":"JP",
     "qs_pg:name":"\u9ed2\u5ca9",
     "qs_pg:name_adm0":"\u65e5\u672c",
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":1125376441,
-    "wof:lastmodified":1566653690,
-    "wof:name":"\u9ed2\u5ca9",
+    "wof:lastmodified":1601427756,
+    "wof:name":"Yuji",
     "wof:parent_id":-1,
     "wof:placetype":"localadmin",
     "wof:repo":"whosonfirst-data-admin-xx",

--- a/data/112/538/284/1/1125382841.geojson
+++ b/data/112/538/284/1/1125382841.geojson
@@ -20,6 +20,12 @@
     "mz:is_funky":1,
     "mz:min_zoom":12.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:eng_x_preferred":[
+        "Wanning"
+    ],
+    "name:zho_x_preferred":[
+        "\u4e07\u5b81\u5e02"
+    ],
     "qs_pg:gn_country":"CN",
     "qs_pg:name":"\u4e07\u5b81\u5e02",
     "qs_pg:name_adm0":"\u4e2d\u570b",
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":1125382841,
-    "wof:lastmodified":1566653955,
-    "wof:name":"\u4e07\u5b81\u5e02",
+    "wof:lastmodified":1601427755,
+    "wof:name":"Wanning",
     "wof:parent_id":-1,
     "wof:placetype":"localadmin",
     "wof:repo":"whosonfirst-data-admin-xx",

--- a/data/112/539/155/5/1125391555.geojson
+++ b/data/112/539/155/5/1125391555.geojson
@@ -20,6 +20,12 @@
     "mz:is_funky":1,
     "mz:min_zoom":12.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:eng_x_preferred":[
+        "Huangping"
+    ],
+    "name:zho_x_preferred":[
+        "\u9ec4\u5e73\u53bf"
+    ],
     "qs_pg:gn_country":"CN",
     "qs_pg:name":"\u9ec4\u5e73\u53bf",
     "qs_pg:name_adm0":"\u4e2d\u570b",
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":1125391555,
-    "wof:lastmodified":1566653848,
-    "wof:name":"\u9ec4\u5e73\u53bf",
+    "wof:lastmodified":1601427754,
+    "wof:name":"Huangping",
     "wof:parent_id":-1,
     "wof:placetype":"localadmin",
     "wof:repo":"whosonfirst-data-admin-xx",

--- a/data/112/539/646/5/1125396465.geojson
+++ b/data/112/539/646/5/1125396465.geojson
@@ -20,6 +20,12 @@
     "mz:is_funky":1,
     "mz:min_zoom":12.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:eng_x_preferred":[
+        "Longjing"
+    ],
+    "name:zho_x_preferred":[
+        "\u9f99\u4e95\u5e02"
+    ],
     "qs_pg:gn_country":"CN",
     "qs_pg:name":"\u9f99\u4e95\u5e02",
     "qs_pg:name_adm0":"\u4e2d\u570b",
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":1125396465,
-    "wof:lastmodified":1566653867,
-    "wof:name":"\u9f99\u4e95\u5e02",
+    "wof:lastmodified":1601427754,
+    "wof:name":"Longjing",
     "wof:parent_id":-1,
     "wof:placetype":"localadmin",
     "wof:repo":"whosonfirst-data-admin-xx",

--- a/data/112/540/328/5/1125403285.geojson
+++ b/data/112/540/328/5/1125403285.geojson
@@ -20,6 +20,15 @@
     "mz:is_funky":1,
     "mz:min_zoom":12.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:eng_x_preferred":[
+        "Mayang Miao"
+    ],
+    "name:eng_x_variant":[
+        "Mayang Miao Autonomous County"
+    ],
+    "name:zho_x_preferred":[
+        "\u9ebb\u9633\u82d7\u65cf\u81ea\u6cbb\u53bf"
+    ],
     "qs_pg:gn_country":"CN",
     "qs_pg:name":"\u9ebb\u9633\u82d7\u65cf\u81ea\u6cbb\u53bf",
     "qs_pg:name_adm0":"\u4e2d\u570b",
@@ -60,8 +69,8 @@
         }
     ],
     "wof:id":1125403285,
-    "wof:lastmodified":1566654698,
-    "wof:name":"\u9ebb\u9633\u82d7\u65cf\u81ea\u6cbb\u53bf",
+    "wof:lastmodified":1601427754,
+    "wof:name":"Mayang Miao",
     "wof:parent_id":-1,
     "wof:placetype":"localadmin",
     "wof:repo":"whosonfirst-data-admin-xx",

--- a/data/112/540/425/1/1125404251.geojson
+++ b/data/112/540/425/1/1125404251.geojson
@@ -20,6 +20,12 @@
     "mz:is_funky":1,
     "mz:min_zoom":12.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:eng_x_preferred":[
+        "Longyan"
+    ],
+    "name:zho_x_preferred":[
+        "\u9f99\u5ca9\u5e02"
+    ],
     "qs_pg:gn_country":"CN",
     "qs_pg:name":"\u9f99\u5ca9\u5e02",
     "qs_pg:name_adm0":"\u4e2d\u570b",
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":1125404251,
-    "wof:lastmodified":1566654548,
-    "wof:name":"\u9f99\u5ca9\u5e02",
+    "wof:lastmodified":1601427754,
+    "wof:name":"Longyan",
     "wof:parent_id":-1,
     "wof:placetype":"localadmin",
     "wof:repo":"whosonfirst-data-admin-xx",

--- a/data/112/540/572/1/1125405721.geojson
+++ b/data/112/540/572/1/1125405721.geojson
@@ -20,6 +20,12 @@
     "mz:is_funky":1,
     "mz:min_zoom":12.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:eng_x_preferred":[
+        "Huanghua"
+    ],
+    "name:zho_x_preferred":[
+        "\u9ec4\u9a85\u5e02"
+    ],
     "qs_pg:gn_country":"CN",
     "qs_pg:name":"\u9ec4\u9a85\u5e02",
     "qs_pg:name_adm0":"\u4e2d\u570b",
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":1125405721,
-    "wof:lastmodified":1566654589,
-    "wof:name":"\u9ec4\u9a85\u5e02",
+    "wof:lastmodified":1601427754,
+    "wof:name":"Huanghua",
     "wof:parent_id":-1,
     "wof:placetype":"localadmin",
     "wof:repo":"whosonfirst-data-admin-xx",

--- a/data/112/541/113/3/1125411133.geojson
+++ b/data/112/541/113/3/1125411133.geojson
@@ -20,6 +20,12 @@
     "mz:is_funky":1,
     "mz:min_zoom":12.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:eng_x_preferred":[
+        "Samsan-myeon"
+    ],
+    "name:kor_x_preferred":[
+        "\uc0bc\uc0b0\uba74"
+    ],
     "qs_pg:gn_country":"KR",
     "qs_pg:name":"\uc0bc\uc0b0\uba74",
     "qs_pg:name_adm0":"\ud55c\uad6d",
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":1125411133,
-    "wof:lastmodified":1566654810,
-    "wof:name":"\uc0bc\uc0b0\uba74",
+    "wof:lastmodified":1601427757,
+    "wof:name":"Samsan-myeon",
     "wof:parent_id":-1,
     "wof:placetype":"localadmin",
     "wof:repo":"whosonfirst-data-admin-xx",

--- a/data/112/541/474/9/1125414749.geojson
+++ b/data/112/541/474/9/1125414749.geojson
@@ -20,6 +20,15 @@
     "mz:is_funky":1,
     "mz:min_zoom":12.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:eng_x_preferred":[
+        "Longyou"
+    ],
+    "name:eng_x_variant":[
+        "Longyou County"
+    ],
+    "name:zho_x_preferred":[
+        "\u9f99\u6e38\u53bf"
+    ],
     "qs_pg:gn_country":"CN",
     "qs_pg:name":"\u9f99\u6e38\u53bf",
     "qs_pg:name_adm0":"\u4e2d\u570b",
@@ -60,8 +69,8 @@
         }
     ],
     "wof:id":1125414749,
-    "wof:lastmodified":1566654785,
-    "wof:name":"\u9f99\u6e38\u53bf",
+    "wof:lastmodified":1601427754,
+    "wof:name":"Longyou",
     "wof:parent_id":-1,
     "wof:placetype":"localadmin",
     "wof:repo":"whosonfirst-data-admin-xx",

--- a/data/112/541/613/9/1125416139.geojson
+++ b/data/112/541/613/9/1125416139.geojson
@@ -20,6 +20,12 @@
     "mz:is_funky":1,
     "mz:min_zoom":12.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:eng_x_preferred":[
+        "Kanose"
+    ],
+    "name:zho_x_preferred":[
+        "\u9e7f\u702c"
+    ],
     "qs_pg:gn_country":"JP",
     "qs_pg:name":"\u9e7f\u702c",
     "qs_pg:name_adm0":"\u65e5\u672c",
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":1125416139,
-    "wof:lastmodified":1566654771,
-    "wof:name":"\u9e7f\u702c",
+    "wof:lastmodified":1601427754,
+    "wof:name":"Kanose",
     "wof:parent_id":-1,
     "wof:placetype":"localadmin",
     "wof:repo":"whosonfirst-data-admin-xx",

--- a/data/112/541/783/9/1125417839.geojson
+++ b/data/112/541/783/9/1125417839.geojson
@@ -20,6 +20,15 @@
     "mz:is_funky":1,
     "mz:min_zoom":12.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:eng_x_preferred":[
+        "Luzhai"
+    ],
+    "name:eng_x_variant":[
+        "Luzhai County"
+    ],
+    "name:zho_x_preferred":[
+        "\u9e7f\u5be8\u53bf"
+    ],
     "qs_pg:gn_country":"CN",
     "qs_pg:name":"\u9e7f\u5be8\u53bf",
     "qs_pg:name_adm0":"\u4e2d\u570b",
@@ -60,8 +69,8 @@
         }
     ],
     "wof:id":1125417839,
-    "wof:lastmodified":1566654752,
-    "wof:name":"\u9e7f\u5be8\u53bf",
+    "wof:lastmodified":1601427754,
+    "wof:name":"Luzhai",
     "wof:parent_id":-1,
     "wof:placetype":"localadmin",
     "wof:repo":"whosonfirst-data-admin-xx",

--- a/data/112/581/235/7/1125812357.geojson
+++ b/data/112/581/235/7/1125812357.geojson
@@ -20,6 +20,12 @@
     "mz:is_funky":1,
     "mz:min_zoom":12.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ara_x_preferred":[
+        "\u0645\u0637\u0631\u0648\u062d"
+    ],
+    "name:eng_x_preferred":[
+        "Matruh"
+    ],
     "qs_pg:gn_country":"EG",
     "qs_pg:name":"\u0645\u0637\u0631\u0648\u062d",
     "qs_pg:name_adm0":"\u0645\u0635\u0631",
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":1125812357,
-    "wof:lastmodified":1566653518,
-    "wof:name":"\u0645\u0637\u0631\u0648\u062d",
+    "wof:lastmodified":1601427756,
+    "wof:name":"Matruh",
     "wof:parent_id":-1,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-xx",

--- a/data/112/583/424/5/1125834245.geojson
+++ b/data/112/583/424/5/1125834245.geojson
@@ -20,6 +20,12 @@
     "mz:is_funky":1,
     "mz:min_zoom":12.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:eng_x_preferred":[
+        "Busan"
+    ],
+    "name:kor_x_preferred":[
+        "\ubd80\uc0b0"
+    ],
     "qs_pg:gn_country":"KR",
     "qs_pg:name":"\ubd80\uc0b0",
     "qs_pg:name_adm0":"\ud55c\uad6d",
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":1125834245,
-    "wof:lastmodified":1566654837,
-    "wof:name":"\ubd80\uc0b0",
+    "wof:lastmodified":1601427757,
+    "wof:name":"Busan",
     "wof:parent_id":-1,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-xx",

--- a/data/112/586/391/1/1125863911.geojson
+++ b/data/112/586/391/1/1125863911.geojson
@@ -20,6 +20,12 @@
     "mz:is_funky":1,
     "mz:min_zoom":12.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u062c\u0628\u064a\u0644"
+    ],
+    "name:eng_x_preferred":[
+        "Al Jubail"
+    ],
     "qs_pg:gn_country":"SA",
     "qs_pg:name":"\u0627\u0644\u062c\u0628\u064a\u0644",
     "qs_pg:name_adm0":"\u0627\u0644\u0633\u0639\u0648\u062f\u064a\u0629",
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":1125863911,
-    "wof:lastmodified":1566653511,
-    "wof:name":"\u0627\u0644\u062c\u0628\u064a\u0644",
+    "wof:lastmodified":1601427756,
+    "wof:name":"Al Jubail",
     "wof:parent_id":-1,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-xx",

--- a/data/112/589/103/9/1125891039.geojson
+++ b/data/112/589/103/9/1125891039.geojson
@@ -20,6 +20,12 @@
     "mz:is_funky":1,
     "mz:min_zoom":12.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ara_x_preferred":[
+        "\u0633\u0627\u0645\u0631\u0627\u0621"
+    ],
+    "name:eng_x_preferred":[
+        "Samarra"
+    ],
     "qs_pg:gn_country":"IQ",
     "qs_pg:name":"\u0633\u0627\u0645\u0631\u0627\u0621",
     "qs_pg:name_adm0":"Iraq",
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":1125891039,
-    "wof:lastmodified":1566653629,
-    "wof:name":"\u0633\u0627\u0645\u0631\u0627\u0621",
+    "wof:lastmodified":1601427756,
+    "wof:name":"Samarra",
     "wof:parent_id":-1,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-xx",

--- a/data/112/589/776/3/1125897763.geojson
+++ b/data/112/589/776/3/1125897763.geojson
@@ -20,6 +20,15 @@
     "mz:is_funky":1,
     "mz:min_zoom":12.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ara_x_preferred":[
+        "\u0648\u0644\u0627\u064a\u0629 \u0627\u0644\u062c\u0644\u0641\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Djelfa"
+    ],
+    "name:eng_x_variant":[
+        "Djelfa Province"
+    ],
     "qs_pg:gn_country":"DZ",
     "qs_pg:name":"\u0648\u0644\u0627\u064a\u0629 \u0627\u0644\u062c\u0644\u0641\u0629",
     "qs_pg:name_adm0":"\u0627\u0644\u062c\u0632\u0627\u0626\u0631",
@@ -60,8 +69,8 @@
         }
     ],
     "wof:id":1125897763,
-    "wof:lastmodified":1566653636,
-    "wof:name":"\u0648\u0644\u0627\u064a\u0629 \u0627\u0644\u062c\u0644\u0641\u0629",
+    "wof:lastmodified":1601427756,
+    "wof:name":"Djelfa",
     "wof:parent_id":-1,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-xx",

--- a/data/112/589/815/1/1125898151.geojson
+++ b/data/112/589/815/1/1125898151.geojson
@@ -20,6 +20,12 @@
     "mz:is_funky":1,
     "mz:min_zoom":12.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0643\u0648\u062a"
+    ],
+    "name:eng_x_preferred":[
+        "Al Kout"
+    ],
     "qs_pg:gn_country":"IQ",
     "qs_pg:name":"\u0627\u0644\u0643\u0648\u062a",
     "qs_pg:name_adm0":"Iraq",
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":1125898151,
-    "wof:lastmodified":1566653642,
-    "wof:name":"\u0627\u0644\u0643\u0648\u062a",
+    "wof:lastmodified":1601427756,
+    "wof:name":"Al Kout",
     "wof:parent_id":-1,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-xx",

--- a/data/112/590/231/1/1125902311.geojson
+++ b/data/112/590/231/1/1125902311.geojson
@@ -20,6 +20,12 @@
     "mz:is_funky":1,
     "mz:min_zoom":12.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:eng_x_preferred":[
+        "Gangneung-si"
+    ],
+    "name:kor_x_preferred":[
+        "\uac15\ub989\uc2dc"
+    ],
     "qs_pg:gn_country":"KR",
     "qs_pg:name":"\uac15\ub989\uc2dc",
     "qs_pg:name_adm0":"\ud55c\uad6d",
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":1125902311,
-    "wof:lastmodified":1566653911,
-    "wof:name":"\uac15\ub989\uc2dc",
+    "wof:lastmodified":1601427757,
+    "wof:name":"Gangneung-si",
     "wof:parent_id":-1,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-xx",

--- a/data/112/595/944/9/1125959449.geojson
+++ b/data/112/595/944/9/1125959449.geojson
@@ -20,6 +20,12 @@
     "mz:is_funky":1,
     "mz:min_zoom":12.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ara_x_preferred":[
+        "\u0646\u0627\u0644\u0648\u062a"
+    ],
+    "name:eng_x_preferred":[
+        "Nalut"
+    ],
     "qs_pg:gn_country":"LY",
     "qs_pg:name":"\u0646\u0627\u0644\u0648\u062a",
     "qs_pg:name_adm0":"Libya",
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":1125959449,
-    "wof:lastmodified":1566653223,
-    "wof:name":"\u0646\u0627\u0644\u0648\u062a",
+    "wof:lastmodified":1601427756,
+    "wof:name":"Nalut",
     "wof:parent_id":-1,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-xx",

--- a/data/112/596/013/5/1125960135.geojson
+++ b/data/112/596/013/5/1125960135.geojson
@@ -20,6 +20,12 @@
     "mz:is_funky":1,
     "mz:min_zoom":12.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ara_x_preferred":[
+        "\u0645\u0642\u062f\u064a\u0634\u0648"
+    ],
+    "name:eng_x_preferred":[
+        "Mogadishu"
+    ],
     "qs_pg:gn_country":"SO",
     "qs_pg:name":"\u0645\u0642\u062f\u064a\u0634\u0648",
     "qs_pg:name_adm0":"Somalia",
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":1125960135,
-    "wof:lastmodified":1566654065,
-    "wof:name":"\u0645\u0642\u062f\u064a\u0634\u0648",
+    "wof:lastmodified":1601427756,
+    "wof:name":"Mogadishu",
     "wof:parent_id":-1,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-xx",

--- a/data/112/596/180/9/1125961809.geojson
+++ b/data/112/596/180/9/1125961809.geojson
@@ -20,6 +20,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ara_x_preferred":[
+        "\u0631\u0648\u0644 \u0636\u0627\u062f\u0646\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Rol Dhadna"
+    ],
     "qs_pg:gn_country":null,
     "qs_pg:name":"\u0631\u0648\u0644 \u0636\u0627\u062f\u0646\u0629",
     "qs_pg:name_adm0":"\u0627\u0644\u0627\u0645\u0627\u0631\u0627\u062a",
@@ -45,8 +51,8 @@
     "wof:belongsto":[
         102191569,
         85632573,
-        85667959,
-        1376833611
+        1376833611,
+        85667959
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,8 +72,8 @@
         }
     ],
     "wof:id":1125961809,
-    "wof:lastmodified":1566654066,
-    "wof:name":"\u0631\u0648\u0644 \u0636\u0627\u062f\u0646\u0629",
+    "wof:lastmodified":1601427756,
+    "wof:name":"Rol Dhadna",
     "wof:parent_id":1376833611,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-xx",

--- a/data/112/597/370/5/1125973705.geojson
+++ b/data/112/597/370/5/1125973705.geojson
@@ -20,6 +20,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ara_x_preferred":[
+        "\u0646\u062e\u0644\u0629 \u062c\u0628\u0644 \u0639\u0644\u0649"
+    ],
+    "name:eng_x_preferred":[
+        "Palm Jebel Ali"
+    ],
     "qs_pg:gn_country":null,
     "qs_pg:name":"\u0646\u062e\u0644\u0629 \u062c\u0628\u0644 \u0639\u0644\u0649",
     "qs_pg:name_adm0":"\u0627\u0644\u0627\u0645\u0627\u0631\u0627\u062a",
@@ -45,8 +51,8 @@
     "wof:belongsto":[
         102191569,
         85632573,
-        85667983,
-        1376833603
+        1376833603,
+        85667983
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,8 +72,8 @@
         }
     ],
     "wof:id":1125973705,
-    "wof:lastmodified":1566653913,
-    "wof:name":"\u0646\u062e\u0644\u0629 \u062c\u0628\u0644 \u0639\u0644\u0649",
+    "wof:lastmodified":1601427756,
+    "wof:name":"Palm Jebel Ali",
     "wof:parent_id":1376833603,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-xx",

--- a/data/112/603/703/1/1126037031.geojson
+++ b/data/112/603/703/1/1126037031.geojson
@@ -20,6 +20,12 @@
     "mz:is_funky":1,
     "mz:min_zoom":12.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ara_x_preferred":[
+        "\u0645\u0631\u0628\u0627\u0637"
+    ],
+    "name:eng_x_preferred":[
+        "Mirbat"
+    ],
     "qs_pg:gn_country":"OM",
     "qs_pg:name":"\u0645\u0631\u0628\u0627\u0637",
     "qs_pg:name_adm0":"\u0639\u0645\u0627\u0646",
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":1126037031,
-    "wof:lastmodified":1566653443,
-    "wof:name":"\u0645\u0631\u0628\u0627\u0637",
+    "wof:lastmodified":1601427756,
+    "wof:name":"Mirbat",
     "wof:parent_id":-1,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-xx",

--- a/data/112/607/015/5/1126070155.geojson
+++ b/data/112/607/015/5/1126070155.geojson
@@ -19,6 +19,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0645\u0631\u0627\u0631"
+    ],
+    "name:eng_x_preferred":[
+        "Al Marar"
+    ],
     "qs_pg:gn_country":null,
     "qs_pg:name":"\u0627\u0644\u0645\u0631\u0627\u0631",
     "qs_pg:name_adm0":"\u0627\u0644\u0627\u0645\u0627\u0631\u0627\u062a",
@@ -42,11 +48,11 @@
     "woe:name_adm1":"\u062f\u0628\u064a",
     "woe:placetype":"Suburb",
     "wof:belongsto":[
-        85667983,
         102191569,
         85632573,
+        1376833603,
         421174961,
-        1376833603
+        85667983
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -67,8 +73,8 @@
         }
     ],
     "wof:id":1126070155,
-    "wof:lastmodified":1566654249,
-    "wof:name":"\u0627\u0644\u0645\u0631\u0627\u0631",
+    "wof:lastmodified":1601427756,
+    "wof:name":"Al Marar",
     "wof:parent_id":421174961,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-xx",

--- a/data/112/609/176/9/1126091769.geojson
+++ b/data/112/609/176/9/1126091769.geojson
@@ -19,6 +19,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:eng_x_preferred":[
+        "I"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30a4"
+    ],
     "qs_pg:gn_country":null,
     "qs_pg:name":"\u30a4",
     "qs_pg:name_adm0":"\u65e5\u672c",
@@ -42,11 +48,11 @@
     "woe:name_adm1":"\u5343\u8449\u770c",
     "woe:placetype":"Suburb",
     "wof:belongsto":[
-        85672797,
         102191569,
         85632429,
+        1108741637,
         102031963,
-        1108741637
+        85672797
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -67,8 +73,8 @@
         }
     ],
     "wof:id":1126091769,
-    "wof:lastmodified":1566654508,
-    "wof:name":"\u30a4",
+    "wof:lastmodified":1601427756,
+    "wof:name":"I",
     "wof:parent_id":102031963,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-xx",


### PR DESCRIPTION
Fixes a portion of whosonfirst-data/whosonfirst-data#183.

This PR updates localized `wof:name` values in records that currently have no `name:eng_x_*` properties. There are other records that will need to be updated as part of this work too, but those will be handled in a separate PR.

The existing `wof:name` should be stored in the appropriate name:* property, with `wof:name` and `name:eng_x_preferred` properties getting updated English name values.

No PIP work needed, these are just property updates.