### PR TITLE
Update names on Taiwan disputed record

### DIFF
--- a/data/172/988/966/3/1729889663.geojson
+++ b/data/172/988/966/3/1729889663.geojson
@@ -32,6 +32,9 @@
         "\u09a4\u09be\u0987\u0993\u09af\u09bc\u09be\u09a8"
     ],
     "name:deu_x_preferred":[
+        "Taiwan"
+    ],
+    "name:deu_x_variant":[
         "Republik China"
     ],
     "name:ell_x_preferred":[
@@ -50,6 +53,9 @@
         "\u091a\u0940\u0928\u0940 \u0917\u0923\u0930\u093e\u091c\u094d\u092f"
     ],
     "name:hun_x_preferred":[
+        "Tajvan"
+    ],
+    "name:hun_x_variant":[
         "K\u00ednai K\u00f6zt\u00e1rsas\u00e1g"
     ],
     "name:ind_x_preferred":[
@@ -68,6 +74,9 @@
         "Taiwan"
     ],
     "name:pol_x_preferred":[
+        "Tajwan"
+    ],
+    "name:pol_x_variant":[
         "Republika Chi\u0144ska"
     ],
     "name:por_x_preferred":[
@@ -77,6 +86,9 @@
         "\u041a\u0438\u0442\u0430\u0439\u0441\u043a\u0430\u044f \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430"
     ],
     "name:spa_x_preferred":[
+        "Isla de Taiw\u00e1n"
+    ],
+    "name:spa_x_variant":[
         "Rep\u00fablica de China"
     ],
     "name:swe_x_preferred":[
@@ -95,7 +107,12 @@
         "\u0110\u00e0i Loan"
     ],
     "name:zho_x_preferred":[
-        "\u4e2d\u83ef\u6c11\u570b"
+        "\u53f0\u7063"
+    ],
+    "name:zho_x_variant":[
+        "\u4e2d\u83ef\u6c11\u570b",
+        "\u53f0\u6e7e",
+        "\u81fa\u7063"
     ],
     "ne:abbrev":"Taiwan",
     "ne:abbrev_len":6,
@@ -270,7 +287,7 @@
         }
     ],
     "wof:id":1729889663,
-    "wof:lastmodified":1616015339,
+    "wof:lastmodified":1665677090,
     "wof:name":"Taiwan",
     "wof:parent_id":-2,
     "wof:placetype":"disputed",

--- a/data/172/988/966/3/1729889663.geojson
+++ b/data/172/988/966/3/1729889663.geojson
@@ -86,10 +86,11 @@
         "\u041a\u0438\u0442\u0430\u0439\u0441\u043a\u0430\u044f \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430"
     ],
     "name:spa_x_preferred":[
-        "Isla de Taiw\u00e1n"
+        "Taiw\u00e1n"
     ],
     "name:spa_x_variant":[
-        "Rep\u00fablica de China"
+        "Rep\u00fablica de China",
+        "Isla de Taiw\u00e1n"
     ],
     "name:swe_x_preferred":[
         "Taiwan"
@@ -317,7 +318,7 @@
         }
     ],
     "wof:id":1729889663,
-    "wof:lastmodified":1665678346,
+    "wof:lastmodified":1665699503,
     "wof:name":"Taiwan",
     "wof:parent_id":-2,
     "wof:placetype":"disputed",

--- a/data/172/988/966/3/1729889663.geojson
+++ b/data/172/988/966/3/1729889663.geojson
@@ -106,13 +106,43 @@
     "name:vie_x_preferred":[
         "\u0110\u00e0i Loan"
     ],
+    "name:zho_cn_x_preferred":[
+        "\u53f0\u6e7e"
+    ],
+    "name:zho_cn_x_variant":[
+        "\u4e2d\u534e\u6c11\u56fd"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u4e2d\u83ef\u6c11\u570b"
+    ],
+    "name:zho_min_nan_x_preferred":[
+        "Tiong-ho\u00e2 B\u00een-kok"
+    ],
+    "name:zho_mo_x_preferred":[
+        "\u4e2d\u83ef\u6c11\u570b"
+    ],
+    "name:zho_my_x_preferred":[
+        "\u4e2d\u534e\u6c11\u56fd"
+    ],
+    "name:zho_sg_x_preferred":[
+        "\u4e2d\u534e\u6c11\u56fd"
+    ],
+    "name:zho_tw_x_preferred":[
+        "\u53f0\u7063"
+    ],
+    "name:zho_tw_x_variant":[
+        "\u4e2d\u83ef\u6c11\u570b"
+    ],
     "name:zho_x_preferred":[
         "\u53f0\u7063"
     ],
     "name:zho_x_variant":[
-        "\u4e2d\u83ef\u6c11\u570b",
         "\u53f0\u6e7e",
+        "\u4e2d\u83ef\u6c11\u570b",
         "\u81fa\u7063"
+    ],
+    "name:zho_yue_x_preferred":[
+        "\u4e2d\u83ef\u6c11\u570b"
     ],
     "ne:abbrev":"Taiwan",
     "ne:abbrev_len":6,
@@ -287,7 +317,7 @@
         }
     ],
     "wof:id":1729889663,
-    "wof:lastmodified":1665677090,
+    "wof:lastmodified":1665678346,
     "wof:name":"Taiwan",
     "wof:parent_id":-2,
     "wof:placetype":"disputed",


### PR DESCRIPTION
Replaces https://github.com/whosonfirst-data/whosonfirst-data-admin-xx/pull/18

This PR updates `name:*` properties in the disputed record for Taiwan, sourced from the other admin records for Taiwan and [Wikidata](https://www.wikidata.org/wiki/Q865).