### PR TITLE
xx concordances, placetype local, and more

### DIFF
--- a/data/172/994/589/1/1729945891.geojson
+++ b/data/172/994/589/1/1729945891.geojson
@@ -689,7 +689,7 @@
         }
     ],
     "wof:id":1729945891,
-    "wof:lastmodified":1694639679,
+    "wof:lastmodified":1695881338,
     "wof:name":"Northern Cyprus",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/172/994/589/3/1729945893.geojson
+++ b/data/172/994/589/3/1729945893.geojson
@@ -444,7 +444,7 @@
         }
     ],
     "wof:id":1729945893,
-    "wof:lastmodified":1694492215,
+    "wof:lastmodified":1695881328,
     "wof:name":"Spratly Islands",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/172/998/920/1/1729989201.geojson
+++ b/data/172/998/920/1/1729989201.geojson
@@ -383,7 +383,7 @@
         }
     ],
     "wof:id":1729989201,
-    "wof:lastmodified":1694492224,
+    "wof:lastmodified":1695881337,
     "wof:name":"Siachen Glacier",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/811/55/85681155.geojson
+++ b/data/856/811/55/85681155.geojson
@@ -360,7 +360,7 @@
         }
     ],
     "wof:id":85681155,
-    "wof:lastmodified":1694493129,
+    "wof:lastmodified":1695884358,
     "wof:name":"Bajo Nuevo Bank",
     "wof:parent_id":-2,
     "wof:placetype":"region",

--- a/data/856/811/87/85681187.geojson
+++ b/data/856/811/87/85681187.geojson
@@ -654,7 +654,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1694493128,
+    "wof:lastmodified":1695884286,
     "wof:name":"Northern Cyprus",
     "wof:parent_id":85632375,
     "wof:placetype":"region",

--- a/data/856/812/67/85681267.geojson
+++ b/data/856/812/67/85681267.geojson
@@ -430,7 +430,7 @@
         }
     ],
     "wof:id":85681267,
-    "wof:lastmodified":1694493264,
+    "wof:lastmodified":1695885136,
     "wof:name":"Kashmir",
     "wof:parent_id":85632277,
     "wof:placetype":"region",

--- a/data/890/440/313/890440313.geojson
+++ b/data/890/440/313/890440313.geojson
@@ -258,7 +258,7 @@
     },
     "wof:country":"XX",
     "wof:created":1469052270,
-    "wof:geomhash":"24b8dcd2302153464359fc266f1f8858",
+    "wof:geomhash":"6fb11ab565655eba6f6be6336a7bca0c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -276,7 +276,7 @@
         }
     ],
     "wof:id":890440313,
-    "wof:lastmodified":1690921946,
+    "wof:lastmodified":1695887184,
     "wof:name":"Leh",
     "wof:parent_id":1796791505,
     "wof:placetype":"county",

--- a/data/890/440/961/890440961.geojson
+++ b/data/890/440/961/890440961.geojson
@@ -134,7 +134,7 @@
         }
     ],
     "wof:id":890440961,
-    "wof:lastmodified":1694493025,
+    "wof:lastmodified":1695886571,
     "wof:name":"Punch",
     "wof:parent_id":1796791507,
     "wof:placetype":"county",

--- a/data/890/445/611/890445611.geojson
+++ b/data/890/445/611/890445611.geojson
@@ -189,7 +189,7 @@
     },
     "wof:country":"XX",
     "wof:created":1469052516,
-    "wof:geomhash":"839bffb71a10c93a2ba0ef74389cf2e2",
+    "wof:geomhash":"4425bc85199d4b72d626b410a627e376",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -207,7 +207,7 @@
         }
     ],
     "wof:id":890445611,
-    "wof:lastmodified":1690921949,
+    "wof:lastmodified":1695887184,
     "wof:name":"Kargil",
     "wof:parent_id":1796791505,
     "wof:placetype":"county",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.